### PR TITLE
Broker and trigger types UTs

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_types_test.go
+++ b/pkg/apis/eventing/v1alpha1/broker_types_test.go
@@ -24,30 +24,32 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var brokerConditionReady = duckv1alpha1.Condition{
-	Type:   BrokerConditionReady,
-	Status: corev1.ConditionTrue,
-}
+var (
+	brokerConditionReady = duckv1alpha1.Condition{
+		Type:   BrokerConditionReady,
+		Status: corev1.ConditionTrue,
+	}
 
-var brokerConditionIngress = duckv1alpha1.Condition{
-	Type:   BrokerConditionIngress,
-	Status: corev1.ConditionTrue,
-}
+	brokerConditionIngress = duckv1alpha1.Condition{
+		Type:   BrokerConditionIngress,
+		Status: corev1.ConditionTrue,
+	}
 
-var brokerConditionChannel = duckv1alpha1.Condition{
-	Type:   BrokerConditionChannel,
-	Status: corev1.ConditionTrue,
-}
+	brokerConditionChannel = duckv1alpha1.Condition{
+		Type:   BrokerConditionChannel,
+		Status: corev1.ConditionTrue,
+	}
 
-var brokerConditionFilter = duckv1alpha1.Condition{
-	Type:   BrokerConditionFilter,
-	Status: corev1.ConditionTrue,
-}
+	brokerConditionFilter = duckv1alpha1.Condition{
+		Type:   BrokerConditionFilter,
+		Status: corev1.ConditionTrue,
+	}
 
-var brokerConditionAddressable = duckv1alpha1.Condition{
-	Type:   BrokerConditionAddressable,
-	Status: corev1.ConditionFalse,
-}
+	brokerConditionAddressable = duckv1alpha1.Condition{
+		Type:   BrokerConditionAddressable,
+		Status: corev1.ConditionFalse,
+	}
+)
 
 func TestBrokerGetCondition(t *testing.T) {
 	tests := []struct {

--- a/pkg/apis/eventing/v1alpha1/broker_types_test.go
+++ b/pkg/apis/eventing/v1alpha1/broker_types_test.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var brokerConditionReady = duckv1alpha1.Condition{
+	Type:   BrokerConditionReady,
+	Status: corev1.ConditionTrue,
+}
+
+var brokerConditionIngress = duckv1alpha1.Condition{
+	Type:   BrokerConditionIngress,
+	Status: corev1.ConditionTrue,
+}
+
+var brokerConditionChannel = duckv1alpha1.Condition{
+	Type:   BrokerConditionChannel,
+	Status: corev1.ConditionTrue,
+}
+
+var brokerConditionFilter = duckv1alpha1.Condition{
+	Type:   BrokerConditionFilter,
+	Status: corev1.ConditionTrue,
+}
+
+var brokerConditionAddressable = duckv1alpha1.Condition{
+	Type:   BrokerConditionAddressable,
+	Status: corev1.ConditionFalse,
+}
+
+func TestBrokerGetCondition(t *testing.T) {
+	tests := []struct {
+		name      string
+		bs        *BrokerStatus
+		condQuery duckv1alpha1.ConditionType
+		want      *duckv1alpha1.Condition
+	}{{
+		name: "single condition",
+		bs: &BrokerStatus{
+			Conditions: []duckv1alpha1.Condition{
+				brokerConditionReady,
+			},
+		},
+		condQuery: duckv1alpha1.ConditionReady,
+		want:      &brokerConditionReady,
+	}, {
+		name: "multiple conditions",
+		bs: &BrokerStatus{
+			Conditions: []duckv1alpha1.Condition{
+				brokerConditionIngress,
+				brokerConditionChannel,
+				brokerConditionFilter,
+			},
+		},
+		condQuery: BrokerConditionFilter,
+		want:      &brokerConditionFilter,
+	}, {
+		name: "multiple conditions, condition false",
+		bs: &BrokerStatus{
+			Conditions: []duckv1alpha1.Condition{
+				brokerConditionChannel,
+				brokerConditionFilter,
+				brokerConditionAddressable,
+			},
+		},
+		condQuery: BrokerConditionAddressable,
+		want:      &brokerConditionAddressable,
+	}, {
+		name: "unknown condition",
+		bs: &BrokerStatus{
+			Conditions: []duckv1alpha1.Condition{
+				brokerConditionAddressable,
+				brokerConditionReady,
+			},
+		},
+		condQuery: duckv1alpha1.ConditionType("foo"),
+		want:      nil,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.bs.GetCondition(test.condQuery)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("unexpected condition (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestBrokerInitializeConditions(t *testing.T) {
+	tests := []struct {
+		name string
+		bs   *BrokerStatus
+		want *BrokerStatus
+	}{{
+		name: "empty",
+		bs:   &BrokerStatus{},
+		want: &BrokerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   BrokerConditionAddressable,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionChannel,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionFilter,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionIngress,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	}, {
+		name: "one false",
+		bs: &BrokerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   BrokerConditionChannel,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+		want: &BrokerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   BrokerConditionAddressable,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionChannel,
+				Status: corev1.ConditionFalse,
+			}, {
+				Type:   BrokerConditionFilter,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionIngress,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	}, {
+		name: "one true",
+		bs: &BrokerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   BrokerConditionFilter,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+		want: &BrokerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   BrokerConditionAddressable,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionChannel,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionFilter,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   BrokerConditionIngress,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   BrokerConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.bs.InitializeConditions()
+			if diff := cmp.Diff(test.want, test.bs, ignoreAllButTypeAndStatus); diff != "" {
+				t.Errorf("unexpected conditions (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestBrokerIsReady(t *testing.T) {
+	tests := []struct {
+		name             string
+		markChannelReady bool
+		markFilterReady  bool
+		markIngressReady bool
+		address          string
+		wantReady        bool
+	}{{
+		name:             "all happy",
+		markChannelReady: true,
+		markFilterReady:  true,
+		markIngressReady: true,
+		address:          "hostname",
+		wantReady:        true,
+	}, {
+		name:             "channel sad",
+		markChannelReady: false,
+		markFilterReady:  true,
+		markIngressReady: true,
+		address:          "hostname",
+		wantReady:        false,
+	}, {
+		name:             "filter sad",
+		markChannelReady: true,
+		markFilterReady:  false,
+		markIngressReady: true,
+		address:          "hostname",
+		wantReady:        false,
+	}, {
+		name:             "ingress sad",
+		markChannelReady: true,
+		markFilterReady:  true,
+		markIngressReady: false,
+		address:          "hostname",
+		wantReady:        false,
+	}, {
+		name:             "addressable sad",
+		markChannelReady: true,
+		markFilterReady:  true,
+		markIngressReady: true,
+		address:          "",
+		wantReady:        false,
+	}, {
+		name:             "all sad",
+		markChannelReady: false,
+		markFilterReady:  false,
+		markIngressReady: false,
+		address:          "",
+		wantReady:        false,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := &BrokerStatus{}
+			if test.markChannelReady {
+				ts.MarkChannelReady()
+			}
+			if test.markFilterReady {
+				ts.MarkFilterReady()
+			}
+			if test.markIngressReady {
+				ts.MarkIngressReady()
+			}
+			ts.SetAddress(test.address)
+			got := ts.IsReady()
+			if test.wantReady != got {
+				t.Errorf("unexpected readiness: want %v, got %v", test.wantReady, got)
+			}
+		})
+	}
+}

--- a/pkg/apis/eventing/v1alpha1/broker_validation.go
+++ b/pkg/apis/eventing/v1alpha1/broker_validation.go
@@ -25,9 +25,11 @@ func (b *Broker) Validate() *apis.FieldError {
 }
 
 func (bs *BrokerSpec) Validate() *apis.FieldError {
+	// TODO implement
 	return nil
 }
 
 func (b *Broker) CheckImmutableFields(og apis.Immutable) *apis.FieldError {
+	// TODO implement
 	return nil
 }

--- a/pkg/apis/eventing/v1alpha1/broker_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/broker_validation_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1

--- a/pkg/apis/eventing/v1alpha1/broker_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/broker_validation_test.go
@@ -15,3 +15,26 @@ limitations under the License.
 */
 
 package v1alpha1
+
+import (
+	"testing"
+)
+
+// No-op test because method does nothing.
+func TestBrokerValidation(t *testing.T) {
+	b := Broker{}
+	_ = b.Validate()
+}
+
+// No-op test because method does nothing.
+func TestBrokerSpecValidation(t *testing.T) {
+	bs := BrokerSpec{}
+	_ = bs.Validate()
+}
+
+// No-op test because method does nothing.
+func TestBrokerImmutableFields(t *testing.T) {
+	original := &Broker{}
+	current := &Broker{}
+	_ = current.CheckImmutableFields(original)
+}

--- a/pkg/apis/eventing/v1alpha1/trigger_defaults_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_defaults_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	defaultBroker        = "default"
+	otherBroker          = "other_broker"
+	defaultTriggerFilter = &TriggerFilter{
+		SourceAndType: &TriggerFilterSourceAndType{
+			Type:   TriggerAnyFilter,
+			Source: TriggerAnyFilter},
+	}
+	otherTriggerFilter = &TriggerFilter{
+		SourceAndType: &TriggerFilterSourceAndType{
+			Type:   "other_type",
+			Source: "other_source"},
+	}
+	defaultTrigger = Trigger{
+		Spec: TriggerSpec{
+			Broker: defaultBroker,
+			Filter: defaultTriggerFilter,
+		},
+	}
+)
+
+func TestTriggerDefaults(t *testing.T) {
+	testCases := map[string]struct {
+		initial  Trigger
+		expected Trigger
+	}{
+		"nil broker": {
+			initial:  Trigger{Spec: TriggerSpec{Filter: otherTriggerFilter}},
+			expected: Trigger{Spec: TriggerSpec{Broker: defaultBroker, Filter: otherTriggerFilter}},
+		},
+		"nil filter": {
+			initial:  Trigger{Spec: TriggerSpec{Broker: otherBroker}},
+			expected: Trigger{Spec: TriggerSpec{Broker: otherBroker, Filter: defaultTriggerFilter}},
+		},
+		"nil broker and nil filter": {
+			initial:  Trigger{},
+			expected: defaultTrigger,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			tc.initial.SetDefaults()
+			if diff := cmp.Diff(tc.expected, tc.initial); diff != "" {
+				t.Fatalf("Unexpected defaults (-want, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/eventing/v1alpha1/trigger_types_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var triggerConditionReady = duckv1alpha1.Condition{
+	Type:   TriggerConditionReady,
+	Status: corev1.ConditionTrue,
+}
+
+var triggerConditionBrokerExists = duckv1alpha1.Condition{
+	Type:   TriggerConditionBrokerExists,
+	Status: corev1.ConditionTrue,
+}
+
+var triggerConditionKubernetesService = duckv1alpha1.Condition{
+	Type:   TriggerConditionKubernetesService,
+	Status: corev1.ConditionTrue,
+}
+
+var triggerConditionVirtualService = duckv1alpha1.Condition{
+	Type:   TriggerConditionVirtualService,
+	Status: corev1.ConditionTrue,
+}
+
+var triggerConditionSubscribed = duckv1alpha1.Condition{
+	Type:   TriggerConditionSubscribed,
+	Status: corev1.ConditionFalse,
+}
+
+func TestTriggerGetCondition(t *testing.T) {
+	tests := []struct {
+		name      string
+		ts        *TriggerStatus
+		condQuery duckv1alpha1.ConditionType
+		want      *duckv1alpha1.Condition
+	}{{
+		name: "single condition",
+		ts: &TriggerStatus{
+			Conditions: []duckv1alpha1.Condition{
+				triggerConditionReady,
+			},
+		},
+		condQuery: duckv1alpha1.ConditionReady,
+		want:      &triggerConditionReady,
+	}, {
+		name: "multiple conditions",
+		ts: &TriggerStatus{
+			Conditions: []duckv1alpha1.Condition{
+				triggerConditionBrokerExists,
+				triggerConditionKubernetesService,
+			},
+		},
+		condQuery: TriggerConditionKubernetesService,
+		want:      &triggerConditionKubernetesService,
+	}, {
+		name: "multiple conditions, condition false",
+		ts: &TriggerStatus{
+			Conditions: []duckv1alpha1.Condition{
+				triggerConditionBrokerExists,
+				triggerConditionKubernetesService,
+				triggerConditionSubscribed,
+			},
+		},
+		condQuery: TriggerConditionSubscribed,
+		want:      &triggerConditionSubscribed,
+	}, {
+		name: "unknown condition",
+		ts: &TriggerStatus{
+			Conditions: []duckv1alpha1.Condition{
+				triggerConditionVirtualService,
+				triggerConditionSubscribed,
+			},
+		},
+		condQuery: duckv1alpha1.ConditionType("foo"),
+		want:      nil,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.ts.GetCondition(test.condQuery)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("unexpected condition (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestTriggerInitializeConditions(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   *TriggerStatus
+		want *TriggerStatus
+	}{{
+		name: "empty",
+		ts:   &TriggerStatus{},
+		want: &TriggerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   TriggerConditionBrokerExists,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionKubernetesService,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionReady,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionSubscribed,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionVirtualService,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	}, {
+		name: "one false",
+		ts: &TriggerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   TriggerConditionVirtualService,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+		want: &TriggerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   TriggerConditionBrokerExists,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionKubernetesService,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionReady,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionSubscribed,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionVirtualService,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}, {
+		name: "one true",
+		ts: &TriggerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   TriggerConditionSubscribed,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+		want: &TriggerStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:   TriggerConditionBrokerExists,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionKubernetesService,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionReady,
+				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   TriggerConditionSubscribed,
+				Status: corev1.ConditionTrue,
+			}, {
+				Type:   TriggerConditionVirtualService,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.ts.InitializeConditions()
+			if diff := cmp.Diff(test.want, test.ts, ignoreAllButTypeAndStatus); diff != "" {
+				t.Errorf("unexpected conditions (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestTriggerIsReady(t *testing.T) {
+	tests := []struct {
+		name                        string
+		markBrokerExists            bool
+		markKubernetesServiceExists bool
+		markVirtualServiceExists    bool
+		markSubscribed              bool
+		wantReady                   bool
+	}{{
+		name:                        "all happy",
+		markBrokerExists:            true,
+		markKubernetesServiceExists: true,
+		markVirtualServiceExists:    true,
+		markSubscribed:              true,
+		wantReady:                   true,
+	}, {
+		name:                        "broker sad",
+		markBrokerExists:            false,
+		markKubernetesServiceExists: true,
+		markVirtualServiceExists:    true,
+		markSubscribed:              true,
+		wantReady:                   false,
+	}, {
+		name:                        "k8s service sad",
+		markBrokerExists:            true,
+		markKubernetesServiceExists: false,
+		markVirtualServiceExists:    true,
+		markSubscribed:              true,
+		wantReady:                   false,
+	}, {
+		name:                        "virtual service sad",
+		markBrokerExists:            true,
+		markKubernetesServiceExists: true,
+		markVirtualServiceExists:    false,
+		markSubscribed:              true,
+		wantReady:                   false,
+	}, {
+		name:                        "subscribed sad",
+		markBrokerExists:            true,
+		markKubernetesServiceExists: true,
+		markVirtualServiceExists:    true,
+		markSubscribed:              false,
+		wantReady:                   false,
+	}, {
+		name:                        "all sad",
+		markBrokerExists:            false,
+		markKubernetesServiceExists: false,
+		markVirtualServiceExists:    false,
+		markSubscribed:              false,
+		wantReady:                   false,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := &TriggerStatus{}
+			if test.markBrokerExists {
+				ts.MarkBrokerExists()
+			}
+			if test.markKubernetesServiceExists {
+				ts.MarkKubernetesServiceExists()
+			}
+			if test.markVirtualServiceExists {
+				ts.MarkVirtualServiceExists()
+			}
+			if test.markSubscribed {
+				ts.MarkSubscribed()
+			}
+			got := ts.IsReady()
+			if test.wantReady != got {
+				t.Errorf("unexpected readiness: want %v, got %v", test.wantReady, got)
+			}
+		})
+	}
+}

--- a/pkg/apis/eventing/v1alpha1/trigger_types_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types_test.go
@@ -24,30 +24,32 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var triggerConditionReady = duckv1alpha1.Condition{
-	Type:   TriggerConditionReady,
-	Status: corev1.ConditionTrue,
-}
+var (
+	triggerConditionReady = duckv1alpha1.Condition{
+		Type:   TriggerConditionReady,
+		Status: corev1.ConditionTrue,
+	}
 
-var triggerConditionBrokerExists = duckv1alpha1.Condition{
-	Type:   TriggerConditionBrokerExists,
-	Status: corev1.ConditionTrue,
-}
+	triggerConditionBrokerExists = duckv1alpha1.Condition{
+		Type:   TriggerConditionBrokerExists,
+		Status: corev1.ConditionTrue,
+	}
 
-var triggerConditionKubernetesService = duckv1alpha1.Condition{
-	Type:   TriggerConditionKubernetesService,
-	Status: corev1.ConditionTrue,
-}
+	triggerConditionKubernetesService = duckv1alpha1.Condition{
+		Type:   TriggerConditionKubernetesService,
+		Status: corev1.ConditionTrue,
+	}
 
-var triggerConditionVirtualService = duckv1alpha1.Condition{
-	Type:   TriggerConditionVirtualService,
-	Status: corev1.ConditionTrue,
-}
+	triggerConditionVirtualService = duckv1alpha1.Condition{
+		Type:   TriggerConditionVirtualService,
+		Status: corev1.ConditionTrue,
+	}
 
-var triggerConditionSubscribed = duckv1alpha1.Condition{
-	Type:   TriggerConditionSubscribed,
-	Status: corev1.ConditionFalse,
-}
+	triggerConditionSubscribed = duckv1alpha1.Condition{
+		Type:   TriggerConditionSubscribed,
+		Status: corev1.ConditionFalse,
+	}
+)
 
 func TestTriggerGetCondition(t *testing.T) {
 	tests := []struct {

--- a/pkg/apis/eventing/v1alpha1/trigger_validation.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_validation.go
@@ -37,7 +37,7 @@ func (ts *TriggerSpec) Validate() *apis.FieldError {
 		errs = errs.Also(fe)
 	}
 
-	if ts.Filter.SourceAndType == nil {
+	if ts.Filter != nil && ts.Filter.SourceAndType == nil {
 		fe := apis.ErrMissingField("filter.sourceAndType")
 		errs = errs.Also(fe)
 	}

--- a/pkg/apis/eventing/v1alpha1/trigger_validation.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_validation.go
@@ -53,12 +53,13 @@ func (ts *TriggerSpec) Validate() *apis.FieldError {
 }
 
 func (t *Trigger) CheckImmutableFields(og apis.Immutable) *apis.FieldError {
+	if og == nil {
+		return nil
+	}
+
 	original, ok := og.(*Trigger)
 	if !ok {
 		return &apis.FieldError{Message: "The provided original was not a Trigger"}
-	}
-	if original == nil {
-		return nil
 	}
 
 	if diff := cmp.Diff(original.Spec.Broker, t.Spec.Broker); diff != "" {

--- a/pkg/apis/eventing/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_validation_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/knative/pkg/apis"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	validTriggerFilter = &TriggerFilter{
+		SourceAndType: &TriggerFilterSourceAndType{
+			Type:   "other_type",
+			Source: "other_source"},
+	}
+	validSubscriber = &SubscriberSpec{
+		Ref: &corev1.ObjectReference{
+			Name:       "subscriber_test",
+			Kind:       "Service",
+			APIVersion: "serving.knative.dev/v1alpha1",
+		},
+	}
+	invalidSubscriber = &SubscriberSpec{
+		Ref: &corev1.ObjectReference{
+			Kind:       "Service",
+			APIVersion: "serving.knative.dev/v1alpha1",
+		},
+	}
+)
+
+func TestTriggerValidation(t *testing.T) {
+	name := "invalid trigger spec"
+	trigger := &Trigger{Spec: TriggerSpec{}}
+
+	want := &apis.FieldError{
+		Paths:   []string{"spec.broker", "spec.filter", "spec.subscriber"},
+		Message: "missing field(s)",
+	}
+
+	t.Run(name, func(t *testing.T) {
+		got := trigger.Validate()
+		if diff := cmp.Diff(want.Error(), got.Error()); diff != "" {
+			t.Errorf("Trigger.Validate (-want, +got) = %v", diff)
+		}
+	})
+}
+
+func TestTriggerSpecValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   *TriggerSpec
+		want *apis.FieldError
+	}{{
+		name: "invalid trigger spec",
+		ts:   &TriggerSpec{},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField("broker", "filter", "subscriber")
+			return fe
+		}(),
+	}, {
+		name: "missing broker",
+		ts: &TriggerSpec{
+			Broker:     "",
+			Filter:     validTriggerFilter,
+			Subscriber: validSubscriber,
+		},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField("broker")
+			return fe
+		}(),
+	}, {
+		name: "missing filter",
+		ts: &TriggerSpec{
+			Broker:     "test_broker",
+			Subscriber: validSubscriber,
+		},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField("filter")
+			return fe
+		}(),
+	}, {
+		name: "missing filter.sourceAndType",
+		ts: &TriggerSpec{
+			Broker:     "test_broker",
+			Filter:     &TriggerFilter{},
+			Subscriber: validSubscriber,
+		},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField("filter.sourceAndType")
+			return fe
+		}(),
+	}, {
+		name: "missing subscriber",
+		ts: &TriggerSpec{
+			Broker: "test_broker",
+			Filter: validTriggerFilter,
+		},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField("subscriber")
+			return fe
+		}(),
+	}, {
+		name: "missing subscriber.ref.name",
+		ts: &TriggerSpec{
+			Broker:     "test_broker",
+			Filter:     validTriggerFilter,
+			Subscriber: invalidSubscriber,
+		},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField("subscriber.ref.name")
+			return fe
+		}(),
+	},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.ts.Validate()
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("%s: Validate TriggerSpec (-want, +got) = %v", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestTriggerImmutableFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  *Trigger
+		original *Trigger
+		want     *apis.FieldError
+	}{{
+		name: "good (no change)",
+		current: &Trigger{
+			Spec: TriggerSpec{
+				Broker: "broker",
+			},
+		},
+		original: &Trigger{
+			Spec: TriggerSpec{
+				Broker: "broker",
+			},
+		},
+		want: nil,
+	}, {
+		name: "new nil is ok",
+		current: &Trigger{
+			Spec: TriggerSpec{
+				Broker: "broker",
+			},
+		},
+		original: nil,
+		want:     nil,
+	}, {
+		name: "good (filter change)",
+		current: &Trigger{
+			Spec: TriggerSpec{
+				Broker: "broker",
+			},
+		},
+		original: &Trigger{
+			Spec: TriggerSpec{
+				Broker: "broker",
+				Filter: validTriggerFilter,
+			},
+		},
+		want: nil,
+	}, {
+		name: "bad (broker change)",
+		current: &Trigger{
+			Spec: TriggerSpec{
+				Broker: "broker",
+			},
+		},
+		original: &Trigger{
+			Spec: TriggerSpec{
+				Broker: "original_broker",
+			},
+		},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec", "broker"},
+			Details: `{string}:
+	-: "original_broker"
+	+: "broker"
+`,
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.current.CheckImmutableFields(test.original)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("CheckImmutableFields (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestTriggerInvalidImmutableType(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  apis.Immutable
+		original apis.Immutable
+		want     *apis.FieldError
+	}{{
+		name: "invalid type",
+		current: &Trigger{
+			Spec: TriggerSpec{
+				Broker: "broker",
+			},
+		},
+		original: nil,
+		want: &apis.FieldError{
+			Message: "The provided original was not a Trigger",
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.current.CheckImmutableFields(test.original)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("CheckImmutableType (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/eventing/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_validation_test.go
@@ -144,8 +144,8 @@ func TestTriggerSpecValidation(t *testing.T) {
 func TestTriggerImmutableFields(t *testing.T) {
 	tests := []struct {
 		name     string
-		current  *Trigger
-		original *Trigger
+		current  apis.Immutable
+		original apis.Immutable
 		want     *apis.FieldError
 	}{{
 		name: "good (no change)",
@@ -169,6 +169,17 @@ func TestTriggerImmutableFields(t *testing.T) {
 		},
 		original: nil,
 		want:     nil,
+	}, {
+		name: "invalid type",
+		current: &Trigger{
+			Spec: TriggerSpec{
+				Broker: "broker",
+			},
+		},
+		original: &Broker{},
+		want: &apis.FieldError{
+			Message: "The provided original was not a Trigger",
+		},
 	}, {
 		name: "good (filter change)",
 		current: &Trigger{
@@ -210,35 +221,6 @@ func TestTriggerImmutableFields(t *testing.T) {
 			got := test.current.CheckImmutableFields(test.original)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("CheckImmutableFields (-want, +got) = %v", diff)
-			}
-		})
-	}
-}
-
-func TestTriggerInvalidImmutableType(t *testing.T) {
-	tests := []struct {
-		name     string
-		current  apis.Immutable
-		original apis.Immutable
-		want     *apis.FieldError
-	}{{
-		name: "invalid type",
-		current: &Trigger{
-			Spec: TriggerSpec{
-				Broker: "broker",
-			},
-		},
-		original: nil,
-		want: &apis.FieldError{
-			Message: "The provided original was not a Trigger",
-		},
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := test.current.CheckImmutableFields(test.original)
-			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
-				t.Errorf("CheckImmutableType (-want, +got) = %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Proposed Changes

- Adding UTs to broker and trigger types

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
