### PR TITLE
Replace the Trigger reconciler's in-memory map with a simple list

### DIFF
--- a/pkg/reconciler/v1alpha1/trigger/trigger.go
+++ b/pkg/reconciler/v1alpha1/trigger/trigger.go
@@ -19,11 +19,9 @@ package trigger
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/logging"
-	"github.com/knative/eventing/pkg/provisioners"
 	"github.com/knative/eventing/pkg/reconciler/names"
 	"github.com/knative/eventing/pkg/reconciler/v1alpha1/broker"
 	"github.com/knative/eventing/pkg/reconciler/v1alpha1/subscription"
@@ -56,8 +54,6 @@ const (
 	// itself when creating events.
 	controllerAgentName = "trigger-controller"
 
-	finalizerName = controllerAgentName
-
 	// Name of the corev1.Events emitted from the reconciliation process.
 	triggerReconciled         = "TriggerReconciled"
 	triggerReconcileFailed    = "TriggerReconcileFailed"
@@ -66,19 +62,11 @@ const (
 	subscriptionCreateFailed  = "SubscriptionCreateFailed"
 )
 
-var dummyValue struct{}
-
 type reconciler struct {
 	client        client.Client
 	restConfig    *rest.Config
 	dynamicClient dynamic.Interface
 	recorder      record.EventRecorder
-
-	triggersLock sync.RWMutex
-	// Contains the triggers that correspond to a particular broker.
-	// We use this to reconcile only the triggers that correspond to a certain broker.
-	// brokerNamespacedName -> triggerReconcileRequest -> dummy struct
-	triggers map[types.NamespacedName]map[reconcile.Request]struct{}
 
 	logger *zap.Logger
 }
@@ -92,7 +80,6 @@ func ProvideController(mgr manager.Manager, logger *zap.Logger) (controller.Cont
 	r := &reconciler{
 		recorder: mgr.GetRecorder(controllerAgentName),
 		logger:   logger,
-		triggers: make(map[types.NamespacedName]map[reconcile.Request]struct{}),
 	}
 	c, err := controller.New(controllerAgentName, mgr, controller.Options{
 		Reconciler: r,
@@ -114,8 +101,9 @@ func ProvideController(mgr manager.Manager, logger *zap.Logger) (controller.Cont
 		}
 	}
 
-	// Watch for Broker changes.
-	if err = c.Watch(&source.Kind{Type: &v1alpha1.Broker{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: &mapAllTriggers{r}}); err != nil {
+	// Watch for Broker changes. E.g. if the Broker is deleted and recreated, we need to reconcile
+	// the Trigger again.
+	if err = c.Watch(&source.Kind{Type: &v1alpha1.Broker{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: &mapBrokerToTriggers{r: r}}); err != nil {
 		return nil, err
 	}
 
@@ -125,24 +113,44 @@ func ProvideController(mgr manager.Manager, logger *zap.Logger) (controller.Cont
 	return c, nil
 }
 
-// mapAllTriggers maps Broker change notifications to Trigger reconcileRequests.
-type mapAllTriggers struct {
+// mapBrokerToTriggers maps Broker changes to all the Triggers that correspond to that Broker.
+type mapBrokerToTriggers struct {
 	r *reconciler
 }
 
-func (m *mapAllTriggers) Map(o handler.MapObject) []reconcile.Request {
-	m.r.triggersLock.RLock()
-	defer m.r.triggersLock.RUnlock()
-	brokerNamespacedName := types.NamespacedName{Namespace: o.Meta.GetNamespace(), Name: o.Meta.GetName()}
-	triggersInBrokerNamespacedName := m.r.triggers[brokerNamespacedName]
-	if triggersInBrokerNamespacedName == nil {
-		return []reconcile.Request{}
+func (b *mapBrokerToTriggers) Map(o handler.MapObject) []reconcile.Request {
+	ctx := context.Background()
+	triggers := make([]reconcile.Request, 0)
+
+	opts := &client.ListOptions{
+		Namespace: o.Meta.GetNamespace(),
+		// Set Raw because if we need to get more than one page, then we will put the continue token
+		// into opts.Raw.Continue.
+		Raw: &metav1.ListOptions{},
 	}
-	reqs := make([]reconcile.Request, 0, len(triggersInBrokerNamespacedName))
-	for name := range triggersInBrokerNamespacedName {
-		reqs = append(reqs, name)
+	for {
+		tl := &v1alpha1.TriggerList{}
+		if err := b.r.client.List(ctx, opts, tl); err != nil {
+			b.r.logger.Error("Error listing Triggers when Broker changed. Some Triggers may not be reconciled.", zap.Error(err), zap.Any("broker", o))
+			return triggers
+		}
+
+		for _, t := range tl.Items {
+			if t.Spec.Broker == o.Meta.GetName() {
+				triggers = append(triggers, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: t.Namespace,
+						Name:      t.Name,
+					},
+				})
+			}
+		}
+		if tl.Continue != "" {
+			opts.Raw.Continue = tl.Continue
+		} else {
+			return triggers
+		}
 	}
-	return reqs
 }
 
 func (r *reconciler) InjectClient(c client.Client) error {
@@ -212,13 +220,8 @@ func (r *reconciler) reconcile(ctx context.Context, t *v1alpha1.Trigger) error {
 
 	if t.DeletionTimestamp != nil {
 		// Everything is cleaned up by the garbage collector.
-		r.removeFromTriggers(t)
-		provisioners.RemoveFinalizer(t, finalizerName)
 		return nil
 	}
-
-	provisioners.AddFinalizer(t, finalizerName)
-	r.AddToTriggers(t)
 
 	b, err := r.getBroker(ctx, t)
 	if err != nil {
@@ -264,58 +267,6 @@ func (r *reconciler) reconcile(ctx context.Context, t *v1alpha1.Trigger) error {
 	t.Status.MarkSubscribed()
 
 	return nil
-}
-
-func (r *reconciler) AddToTriggers(t *v1alpha1.Trigger) {
-	name := reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: t.Namespace,
-			Name:      t.Name,
-		},
-	}
-
-	brokerNamespacedName := types.NamespacedName{
-		Namespace: t.Namespace,
-		Name:      t.Spec.Broker}
-
-	// We will be reconciling an already existing Trigger far more often than adding a new one, so
-	// check with a read lock before using the write lock.
-	r.triggersLock.RLock()
-	_, present := r.triggers[brokerNamespacedName][name]
-	r.triggersLock.RUnlock()
-	if present {
-		// Already present in the map.
-		return
-	}
-
-	r.triggersLock.Lock()
-	triggersInBrokerNamespacedName := r.triggers[brokerNamespacedName]
-	if triggersInBrokerNamespacedName == nil {
-		r.triggers[brokerNamespacedName] = make(map[reconcile.Request]struct{})
-		triggersInBrokerNamespacedName = r.triggers[brokerNamespacedName]
-	}
-	triggersInBrokerNamespacedName[name] = dummyValue
-	r.triggersLock.Unlock()
-}
-
-func (r *reconciler) removeFromTriggers(t *v1alpha1.Trigger) {
-	name := reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: t.Namespace,
-			Name:      t.Name,
-		},
-	}
-
-	brokerNamespacedName := types.NamespacedName{
-		Namespace: t.Namespace,
-		Name:      t.Spec.Broker}
-
-	r.triggersLock.Lock()
-	triggersInBrokerNamespacedName := r.triggers[brokerNamespacedName]
-	if triggersInBrokerNamespacedName != nil {
-		delete(triggersInBrokerNamespacedName, name)
-	}
-	r.triggersLock.Unlock()
 }
 
 // updateStatus may in fact update the trigger's finalizers in addition to the status.
@@ -440,7 +391,7 @@ func (r *reconciler) reconcileK8sService(ctx context.Context, t *v1alpha1.Trigge
 	expected.Spec.ClusterIP = current.Spec.ClusterIP
 	if !equality.Semantic.DeepDerivative(expected.Spec, current.Spec) {
 		current.Spec = expected.Spec
-		err := r.client.Update(ctx, current)
+		err = r.client.Update(ctx, current)
 		if err != nil {
 			return nil, err
 		}
@@ -524,7 +475,7 @@ func (r *reconciler) reconcileVirtualService(ctx context.Context, t *v1alpha1.Tr
 	expected := newVirtualService(t, svc)
 	if !equality.Semantic.DeepDerivative(expected.Spec, virtualService.Spec) {
 		virtualService.Spec = expected.Spec
-		err := r.client.Update(ctx, virtualService)
+		err = r.client.Update(ctx, virtualService)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/reconciler/v1alpha1/trigger/trigger_test.go
+++ b/pkg/reconciler/v1alpha1/trigger/trigger_test.go
@@ -22,30 +22,22 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/knative/eventing/pkg/utils"
-
-	"github.com/knative/eventing/pkg/provisioners"
-
-	"github.com/knative/eventing/pkg/reconciler/names"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	"github.com/knative/eventing/pkg/reconciler/names"
 	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
+	"github.com/knative/eventing/pkg/utils"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -77,12 +69,12 @@ var (
 
 func init() {
 	// Add types to scheme
-	v1alpha1.AddToScheme(scheme.Scheme)
-	istiov1alpha3.AddToScheme(scheme.Scheme)
+	_ = v1alpha1.AddToScheme(scheme.Scheme)
+	_ = istiov1alpha3.AddToScheme(scheme.Scheme)
 }
 
 func TestProvideController(t *testing.T) {
-	//TODO(grantr) This needs a mock of manager.Manager. Creating a manager
+	// TODO(grantr) This needs a mock of manager.Manager. Creating a manager
 	// with a fake Config fails because the Manager tries to contact the
 	// apiserver.
 
@@ -455,7 +447,6 @@ func TestReconcile(t *testing.T) {
 			restConfig:    &rest.Config{},
 			recorder:      recorder,
 			logger:        zap.NewNop(),
-			triggers:      make(map[types.NamespacedName]map[reconcile.Request]struct{}),
 		}
 		tc.ReconcileKey = fmt.Sprintf("%s/%s", testNS, triggerName)
 		tc.IgnoreTimes = true
@@ -494,7 +485,6 @@ func makeTrigger() *v1alpha1.Trigger {
 
 func makeReadyTrigger() *v1alpha1.Trigger {
 	t := makeTrigger()
-	provisioners.AddFinalizer(t, finalizerName)
 	t.Status.InitializeConditions()
 	t.Status.MarkBrokerExists()
 	t.Status.SubscriberURI = fmt.Sprintf("http://%s.%s.svc.%s/", subscriberName, testNS, utils.GetClusterDomainName())


### PR DESCRIPTION
## Proposed Changes

- Replace the Trigger reconciler's in-memory map with a simple list, utilizing the fact that Controller Runtime already has the results of the List cached.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
