### PR TITLE
Do not DeepCopy() in Reconcile(), as controller-runtime already did it for us

### DIFF
--- a/pkg/reconciler/v1alpha1/broker/broker.go
+++ b/pkg/reconciler/v1alpha1/broker/broker.go
@@ -151,7 +151,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		r.recorder.Event(broker, corev1.EventTypeNormal, brokerReconciled, "Broker reconciled")
 	}
 
-	if _, err = r.updateStatus(broker.DeepCopy()); err != nil {
+	if _, err = r.updateStatus(broker); err != nil {
 		logging.FromContext(ctx).Error("Failed to update Broker status", zap.Error(err))
 		r.recorder.Eventf(broker, corev1.EventTypeWarning, brokerUpdateStatusFailed, "Failed to update Broker's status: %v", err)
 		return reconcile.Result{}, err

--- a/pkg/reconciler/v1alpha1/trigger/trigger.go
+++ b/pkg/reconciler/v1alpha1/trigger/trigger.go
@@ -183,9 +183,6 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	// Modify a copy, not the original.
-	trigger = trigger.DeepCopy()
-
 	// Reconcile this copy of the Trigger and then write back any status updates regardless of
 	// whether the reconcile error out.
 	reconcileErr := r.reconcile(ctx, trigger)


### PR DESCRIPTION
Do not DeepCopy() in Reconcile(), as controller-runtime already did it for us.